### PR TITLE
Add "catchOutput" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ runas = require 'runas'
 * `options` Object
   * `hide` Boolean - Hide the console window, `true` by default.
   * `admin` Boolean - Run command as administrator, `false` by default.
+  * `catchOutput` Boolean - Catch the stdout and stderr of the command, `false`
+    by default.
   * `stdin` String - String which would be passed as stdin input.
 
 Launches a new process with the given `command`, with command line arguments in
@@ -33,8 +35,17 @@ Launches a new process with the given `command`, with command line arguments in
 This function is synchronous and returns the exit code when the `command`
 finished.
 
+When the `catchOutput` option is specified to `true`, an object that contains
+`exitCode`, `stdout` and `stderr` will be returned.
+
 ## Limitations
 
-* The `admin` option has only been implemented on Windows and OSX.
+* The `admin` option has only been implemented on Windows and OS X.
 * The `stdin` option has only been implemented on POSIX systems.
 * The `hide` option is only meaningful on Windows.
+* When `catchOutput` is `true`,
+  * on Linux `exitCode`, `stdout` and `stderr` will be returned,
+  * on OS X
+    * if `admin` is `false`, `exitCode`, `stdout` and `stderr` will be returned,
+    * if `admin` is `true`, `exitCode` and `stdout` will be returned,
+  * on Windows only `exitCode` will be returned.

--- a/src/fork.h
+++ b/src/fork.h
@@ -13,6 +13,7 @@ bool Fork(const std::string& command,
           const std::vector<std::string>& args,
           const std::string& std_input,
           std::string* std_output,
+          std::string* std_error,
           int options,
           int* exit_code);
 

--- a/src/fork.h
+++ b/src/fork.h
@@ -12,6 +12,7 @@ std::vector<char*> StringVectorToCharStarVector(
 bool Fork(const std::string& command,
           const std::vector<std::string>& args,
           const std::string& std_input,
+          std::string* std_output,
           int options,
           int* exit_code);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -35,8 +35,9 @@ NAN_METHOD(Runas) {
   if (!v_stdin->IsUndefined())
     std_input = *String::Utf8Value(v_stdin);
 
+  std::string std_output;
   int code = -1;
-  runas::Runas(command, c_args, std_input, options, &code);
+  runas::Runas(command, c_args, std_input, &std_output, options, &code);
   NanReturnValue(NanNew<Integer>(code));
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -36,15 +36,19 @@ NAN_METHOD(Runas) {
     std_input = *String::Utf8Value(v_stdin);
 
   std::string std_output;
-  bool need_stdout = v_options->Get(NanNew<String>("stdout"))->BooleanValue();
+  bool catch_output = v_options->Get(NanNew<String>("catchOutput"))->BooleanValue();
 
   int code = -1;
-  runas::Runas(command, c_args, std_input, need_stdout ? &std_output : NULL, options, &code);
+  runas::Runas(command, c_args, std_input, catch_output ? &std_output : NULL, options, &code);
 
-  if (need_stdout && code == 0)
-    NanReturnValue(NanNew<String>(std_output.data(), std_output.size()));
-  else
+  if (catch_output && code == 0) {
+    Handle<Object> result = NanNew<Object>();
+    result->Set(NanNew<String>("exitCode"), NanNew<Integer>(code));
+    result->Set(NanNew<String>("stdout"), NanNew<String>(std_output.data(), std_output.size()));
+    NanReturnValue(result);
+  } else {
     NanReturnValue(NanNew<Integer>(code));
+  }
 }
 
 void Init(Handle<Object> exports) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -35,16 +35,24 @@ NAN_METHOD(Runas) {
   if (!v_stdin->IsUndefined())
     std_input = *String::Utf8Value(v_stdin);
 
-  std::string std_output;
+  std::string std_output, std_error;
   bool catch_output = v_options->Get(NanNew<String>("catchOutput"))->BooleanValue();
 
   int code = -1;
-  runas::Runas(command, c_args, std_input, catch_output ? &std_output : NULL, options, &code);
+  runas::Runas(command, c_args,
+               std_input,
+               catch_output ? &std_output : NULL,
+               catch_output ? &std_error : NULL,
+               options,
+               &code);
 
   if (catch_output) {
     Handle<Object> result = NanNew<Object>();
     result->Set(NanNew<String>("exitCode"), NanNew<Integer>(code));
-    result->Set(NanNew<String>("stdout"), NanNew<String>(std_output.data(), std_output.size()));
+    result->Set(NanNew<String>("stdout"),
+                NanNew<String>(std_output.data(), std_output.size()));
+    result->Set(NanNew<String>("stderr"),
+                NanNew<String>(std_error.data(), std_error.size()));
     NanReturnValue(result);
   } else {
     NanReturnValue(NanNew<Integer>(code));

--- a/src/main.cc
+++ b/src/main.cc
@@ -36,9 +36,15 @@ NAN_METHOD(Runas) {
     std_input = *String::Utf8Value(v_stdin);
 
   std::string std_output;
+  bool need_stdout = v_options->Get(NanNew<String>("stdout"))->BooleanValue();
+
   int code = -1;
-  runas::Runas(command, c_args, std_input, &std_output, options, &code);
-  NanReturnValue(NanNew<Integer>(code));
+  runas::Runas(command, c_args, std_input, need_stdout ? &std_output : NULL, options, &code);
+
+  if (need_stdout && code == 0)
+    NanReturnValue(NanNew<String>(std_output.data(), std_output.size()));
+  else
+    NanReturnValue(NanNew<Integer>(code));
 }
 
 void Init(Handle<Object> exports) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -41,7 +41,7 @@ NAN_METHOD(Runas) {
   int code = -1;
   runas::Runas(command, c_args, std_input, catch_output ? &std_output : NULL, options, &code);
 
-  if (catch_output && code == 0) {
+  if (catch_output) {
     Handle<Object> result = NanNew<Object>();
     result->Set(NanNew<String>("exitCode"), NanNew<Integer>(code));
     result->Set(NanNew<String>("stdout"), NanNew<String>(std_output.data(), std_output.size()));

--- a/src/runas.h
+++ b/src/runas.h
@@ -18,6 +18,7 @@ bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
            std::string* std_output,
+           std::string* std_error,
            int options,
            int* exit_code);
 

--- a/src/runas.h
+++ b/src/runas.h
@@ -17,6 +17,7 @@ enum Options {
 bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
+           std::string* std_output,
            int options,
            int* exit_code);
 

--- a/src/runas_darwin.cc
+++ b/src/runas_darwin.cc
@@ -33,6 +33,7 @@ OSStatus ExecuteWithPrivileges(AuthorizationRef authorization,
 bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
+           std::string* std_output,
            int options,
            int* exit_code) {
   // Use fork when "admin" is false.

--- a/src/runas_darwin.cc
+++ b/src/runas_darwin.cc
@@ -34,6 +34,7 @@ bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
            std::string* std_output,
+           std::string* std_error,
            int options,
            int* exit_code) {
   // Use fork when "admin" is false.

--- a/src/runas_darwin.cc
+++ b/src/runas_darwin.cc
@@ -39,7 +39,7 @@ bool Runas(const std::string& command,
            int* exit_code) {
   // Use fork when "admin" is false.
   if (!(options & OPTION_ADMIN))
-    return Fork(command, args, std_input, std_output, options, exit_code);
+    return Fork(command, args, std_input, std_output, std_error, options, exit_code);
 
   if (!g_auth && AuthorizationCreate(NULL,
                                      kAuthorizationEmptyEnvironment,

--- a/src/runas_darwin.cc
+++ b/src/runas_darwin.cc
@@ -70,6 +70,18 @@ bool Runas(const std::string& command,
       p += r;
     }
   }
+
+  // Read from stdout.
+  if (std_output) {
+    char buffer[512];
+    while (true) {
+      size_t r = fread(buffer, sizeof(char), 512, pipe);
+      if (r == 0)
+        break;
+      std_output->append(buffer, r);
+    }
+  }
+
   fclose(pipe);
 
   int r, status;

--- a/src/runas_darwin.cc
+++ b/src/runas_darwin.cc
@@ -38,7 +38,7 @@ bool Runas(const std::string& command,
            int* exit_code) {
   // Use fork when "admin" is false.
   if (!(options & OPTION_ADMIN))
-    return Fork(command, args, std_input, options, exit_code);
+    return Fork(command, args, std_input, std_output, options, exit_code);
 
   if (!g_auth && AuthorizationCreate(NULL,
                                      kAuthorizationEmptyEnvironment,

--- a/src/runas_posix.cc
+++ b/src/runas_posix.cc
@@ -11,7 +11,7 @@ bool Runas(const std::string& command,
            std::string* std_error,
            int options,
            int* exit_code) {
-  return Fork(command, args, std_input, std_output, options, exit_code);
+  return Fork(command, args, std_input, std_output, std_error, options, exit_code);
 }
 
 }  // namespace runas

--- a/src/runas_posix.cc
+++ b/src/runas_posix.cc
@@ -7,6 +7,7 @@ namespace runas {
 bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
+           std::string* std_output,
            int options,
            int* exit_code) {
   return Fork(command, args, std_input, options, exit_code);

--- a/src/runas_posix.cc
+++ b/src/runas_posix.cc
@@ -8,6 +8,7 @@ bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
            std::string* std_output,
+           std::string* std_error,
            int options,
            int* exit_code) {
   return Fork(command, args, std_input, std_output, options, exit_code);

--- a/src/runas_posix.cc
+++ b/src/runas_posix.cc
@@ -10,7 +10,7 @@ bool Runas(const std::string& command,
            std::string* std_output,
            int options,
            int* exit_code) {
-  return Fork(command, args, std_input, options, exit_code);
+  return Fork(command, args, std_input, std_output, options, exit_code);
 }
 
 }  // namespace runas

--- a/src/runas_win.cc
+++ b/src/runas_win.cc
@@ -54,6 +54,7 @@ bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
            std::string* std_output,
+           std::string* std_error,
            int options,
            int* exit_code) {
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);

--- a/src/runas_win.cc
+++ b/src/runas_win.cc
@@ -53,6 +53,7 @@ std::string QuoteCmdArg(const std::string& arg) {
 bool Runas(const std::string& command,
            const std::vector<std::string>& args,
            const std::string& std_input,
+           std::string* std_output,
            int options,
            int* exit_code) {
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);


### PR DESCRIPTION
When the `catchOutput` option is specified to `true`, output of the command will be caught and `exitCode`, `stdout` and `stderr` will be returned.

@benogle On OS X we can not get `stderr` if `admin` is `true`, because of the limitation of `ExecuteWithPrivileges` API.

Fixes #13.