### PR TITLE
Add a TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+interface Options {
+  hide?: boolean
+  admin?: boolean
+  catchOutput?: boolean
+  stdin?: string
+}
+interface CatchOutputOptions extends Options {
+  catchOutput: true
+}
+
+interface CommandOutput {
+  exitCode: number
+  stdout?: string
+  stderr?: string
+}
+
+declare function runas(command: string, args?: ReadonlyArray<string>, options?: Options): number
+declare function runas(command: string, args: ReadonlyArray<string>, options: CatchOutputOptions): CommandOutput
+
+export = runas


### PR DESCRIPTION
This allows TypeScript users to just `npm install runas` and use it right away.